### PR TITLE
outputting all files from the zip in the original file structure

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,19 +53,12 @@ function fontello () {
               fileName = path.basename(pathName);
               entry.path = fileName;
 
-              switch (dirName) {
-                case 'css':
-                case 'font':
-                  var file = new $.File({
-                    cwd : "./",
-                    path : entry.path,
-                    contents: Buffer.concat(chunks)
-                  });
-                  self.push(file);
-                  break;
-                default:
-                  return entry.autodrain();
-              }
+              var file = new $.File({
+                cwd : "./",
+                path : (dirName ? (dirName + '/') : '')+ entry.path,
+                contents: Buffer.concat(chunks)
+              });
+              self.push(file);
             }
             cb()
           }))


### PR DESCRIPTION
Thank you gillbeits for providing this gulp plugin!

When using this plugin, thought, I found that I needed (a) the supporting files like demo.html and license file, and (b) to preserve the `font/` and 'css/` directory structure.

These changes modify the code to behave the way I needed. I am not sure if you would be interested in this, or maybe if you would like to introduce an option to turn this behavior on?
