### PR TITLE
Support piping a modified config file

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -74,7 +74,8 @@ function fontello (opts) {
 
     needle.post(opts.host, {
       config: {
-        file: file.path,
+        buffer: file.contents,
+        filename: 'fontello.json',
         content_type: 'application/json'
       }
     }, { multipart: true }).pipe(stream);


### PR DESCRIPTION
needle can upload a buffer, so this would allow the modified contents of fontello.json to be used rather than the unmodified contents on disk.