### PR TITLE
add a way to cache fontello results

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@
 var
   HOST        = 'http://fontello.com',
 
+  crypto      = require('crypto'),
   needle      = require('needle'),
   through2    = require('through2'),
   AdmZip      = require('adm-zip'),
@@ -29,56 +30,86 @@ function fontello (opts) {
   return through2.obj(function (file, enc, callback) {
     var self = this;
 
-    var stream = through2.obj(function (file) {
-      if (!file.toString()) {
-        throw new PluginError(PLUGIN_NAME, "No session at Fontello for zip archive");
-      }
+    var process = function (zipContents, callback) {
+      var
+        zip = new AdmZip(zipContents),
+        zipEntries = zip.getEntries()
+        ;
 
-      needle.get(opts.host + "/" + file.toString() + "/get", function(error, response) {
-        if (error) {
-          throw error;
+      zipEntries.forEach(function (zipEntry) {
+        var dirName, fileName, pathName, _ref;
+
+        if (zipEntry.isDirectory) return;
+
+        pathName = zipEntry.entryName;
+        dirName = (_ref = path.dirname(pathName).match(/\/([^\/]*)$/)) != null ? _ref[1] : void 0;
+        fileName = path.basename(pathName);
+
+        if (opts.assetsOnly && !dirName) return;
+
+        var content = zipEntry.getData();
+        if (opts['font'] && opts['font'] != 'font' && path.extname(fileName) == '.css') {
+          content = new Buffer(String(content).replace(new RegExp('\.\.\/font\/', 'g'), '../' + opts['font'] + '/'));
         }
 
-        var
-          zip = new AdmZip(response.body),
-          zipEntries = zip.getEntries()
-          ;
+        var file = new $.File({
+          cwd: "./",
+          path: (dirName ? ((opts[dirName] ? opts[dirName] : dirName) + '/') : '') + fileName,
+          contents: content
+        });
+        self.push(file);
+      });
 
-        zipEntries.forEach(function(zipEntry) {
-          var dirName, fileName, pathName, _ref;
+      callback();
+    };
 
-          if (zipEntry.isDirectory) return;
+    var fetchFromHost = function (callback) {
+      var stream = through2.obj(function (file) {
+        if (!file.toString()) {
+          throw new PluginError(PLUGIN_NAME, "No session at Fontello for zip archive");
+        }
 
-          pathName = zipEntry.entryName;
-          dirName = (_ref = path.dirname(pathName).match(/\/([^\/]*)$/)) != null ? _ref[1] : void 0;
-          fileName = path.basename(pathName);
-
-          if (opts.assetsOnly && !dirName) return;
-
-          var content = zipEntry.getData();
-          if (opts['font'] && opts['font'] != 'font' && path.extname(fileName) == '.css') {
-            content = new Buffer(String(content).replace(new RegExp('\.\.\/font\/', 'g'), '../' + opts['font'] + '/'));
+        needle.get(opts.host + "/" + file.toString() + "/get", function (error, response) {
+          if (error) {
+            throw error;
           }
 
-          var file = new $.File({
-            cwd : "./",
-            path : (dirName ? ((opts[dirName] ? opts[dirName] : dirName) + '/') : '')+ fileName,
-            contents: content
-          });
-          self.push(file);
+          // store in cache if configured
+          if (opts.cache) {
+            opts.cache.set(configHash, response.body);
+          }
+
+          process(response.body, callback);
         });
-
-        callback();
       });
-    });
 
-    needle.post(opts.host, {
-      config: {
-        buffer: file.contents,
-        filename: 'fontello.json',
-        content_type: 'application/json'
-      }
-    }, { multipart: true }).pipe(stream);
+      needle.post(opts.host, {
+        config: {
+          buffer: file.contents,
+          filename: 'fontello.json',
+          content_type: 'application/json'
+        }
+      }, {multipart: true}).pipe(stream);
+    };
+
+    // create SHA256 of the contents of the config file
+    var configHash = crypto.createHash('sha256').update(file.contents).digest('hex');
+
+    // use cache if configured
+    if (opts.cache) {
+      // check cache first
+      opts.cache.get(configHash, function (error, cachedResponseBody) {
+        // on cache err or empty response use normal fetch
+        if (error || !cachedResponseBody) {
+          fetchFromHost(callback);
+        } else {
+          $.log('using cached fontello zip for config with sha1: ' + configHash);
+          process(cachedResponseBody, callback);
+        }
+      });
+    } else {
+      fetchFromHost(callback);
+    }
   });
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@
 var
   HOST        = 'http://fontello.com',
 
+  fs          = require('fs'),
   crypto      = require('crypto'),
   needle      = require('needle'),
   through2    = require('through2'),
@@ -112,5 +113,32 @@ function fontello (opts) {
     }
   });
 }
+
+/**
+ * simple file-system based cache
+ *
+ * @param cacheDir
+ * @returns {{get: 'get', set: 'set'}}
+ */
+fontello.simpleFsCache = function(cacheDir) {
+  if (!fs.lstatSync(cacheDir).isDirectory()) {
+    fs.mkdirSync(cacheDir);
+  }
+
+  return {
+    'get': function(file, cb) {
+      fs.readFile(path.join(cacheDir, file + ".cached.zip"), function(err, result) {
+        if (err || !result) {
+          cb();
+        } else {
+          cb(null, result);
+        }
+      });
+    },
+    'set': function(file, response) {
+      fs.writeFile(path.join(cacheDir, file + ".cached.zip"), response, function noop() {});
+    }
+  }
+};
 
 module.exports = fontello;


### PR DESCRIPTION
over the past year I've experienced numerous frustrations from fontello requests being slow and timing out, today finally the day came it was too much, so I figured a simple fix would be to cache some stuff locally (considering I rarely modify my fontello config).

the `opts.cache` just needs an object with `get(file, cb)` and `set(file, response)`: 
```javascript
return gulp.src('./fontello-config.json')
      .pipe(fontello({
          cache: (function() {
              cacheDir = "./fontello-cache/";
              return {
                  'get': function(file, cb) {
                      fs.readFile(path.join(cacheDir, file + ".cached.zip"), function(err, result) {
                          if (err || !result) {
                              cb();
                          } else {
                              cb(null, result);
                          }
                      });
                  },
                  'set': function(file, response) {
                      fs.writeFile(path.join(cacheDir, file + ".cached.zip"), response, function noop() {});
                  }
              }
          })()
      }))
      .pipe(gulp.dest('./www/fontello/'));
```

to make life easy there's a basic file-system based implementation already:
```javascript
    return gulp.src('./fontello-config.json')
        .pipe(fontello({
            cache: fontello.simpleFsCache('./fontello-cache')
        }))
        .pipe(gulp.dest('./www/fontello/'));
```