### PR TITLE
Remove gulp-utils dependency

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,11 +11,12 @@ var
   through2    = require('through2'),
   AdmZip      = require('adm-zip'),
   path        = require('path'),
-  $           = require('gulp-util'),
+  Vinyl       = reguire('vinyl'),
+  log         = require('fancy-log'),
   yargs       = require('yargs'),
   extend      = require('util')._extend,
 
-  PluginError = $.PluginError
+  PluginError = require('gulp-error')
   ;
 
 const PLUGIN_NAME = 'gulp-fontello';
@@ -53,7 +54,7 @@ function fontello (opts) {
           content = new Buffer(String(content).replace(new RegExp('\.\.\/font\/', 'g'), '../' + opts['font'] + '/'));
         }
 
-        var file = new $.File({
+        var file = new Vinyl({
           cwd: "./",
           path: (dirName ? ((opts[dirName] ? opts[dirName] : dirName) + '/') : '') + fileName,
           contents: content
@@ -104,7 +105,7 @@ function fontello (opts) {
         if (error || !cachedResponseBody) {
           fetchFromHost(callback);
         } else {
-          $.log('using cached fontello zip for config with sha1: ' + configHash);
+          log('using cached fontello zip for config with sha1: ' + configHash);
           process(cachedResponseBody, callback);
         }
       });

--- a/package.json
+++ b/package.json
@@ -12,11 +12,13 @@
     "url": "https://github.com/gillbeits/gulp-fontello.git"
   },
   "dependencies": {
-    "gulp-util": ">=3.0",
+    "adm-zip": ">=0.4",
+    "fancy-log": "^1.3.2",
+    "gulp-error": "^0.1.4",
     "needle": ">=0.9",
     "path": ">=0.11",
     "through2": ">=0.6",
-    "adm-zip": ">=0.4",
+    "vinyl": "^2.1.0",
     "yargs": "^3.31.0"
   },
   "keywords": [


### PR DESCRIPTION
`gulp-utils` [has been deprecated](https://github.com/gulpjs/gulp-util)
And it breaks [gulp  version 4](https://github.com/gulpjs/gulp/issues/2065).
`gulp-utils` module has been replaced with suggested modules.