### PR TITLE
Add proxy support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,7 +32,7 @@ function fontello (opts) {
   return through2.obj(function (file, enc, callback) {
     var self = this;
 
-    var process = function (zipContents, callback) {
+    var processResponse = function (zipContents, callback) {
       var
         zip = new AdmZip(zipContents),
         zipEntries = zip.getEntries()
@@ -71,7 +71,11 @@ function fontello (opts) {
           throw new PluginError(PLUGIN_NAME, "No session at Fontello for zip archive");
         }
 
-        needle.get(opts.host + "/" + file.toString() + "/get", function (error, response) {
+        var reqOpts = {};
+        if (process.env.HTTP_PROXY) {
+          reqOpts.proxy = process.env.HTTP_PROXY;
+        }
+        needle.get(opts.host + "/" + file.toString() + "/get", reqOpts, function (error, response) {
           if (error) {
             throw error;
           }
@@ -81,17 +85,21 @@ function fontello (opts) {
             opts.cache.set(configHash, response.body);
           }
 
-          process(response.body, callback);
+          processResponse(response.body, callback);
         });
       });
 
+      var reqOpts = { multipart: true };
+      if (process.env.HTTP_PROXY) {
+        reqOpts.proxy = process.env.HTTP_PROXY;
+      }
       needle.post(opts.host, {
         config: {
           buffer: file.contents,
           filename: 'fontello.json',
           content_type: 'application/json'
         }
-      }, {multipart: true}).pipe(stream);
+      }, reqOpts).pipe(stream);
     };
 
     // create SHA256 of the contents of the config file
@@ -106,7 +114,7 @@ function fontello (opts) {
           fetchFromHost(callback);
         } else {
           log('using cached fontello zip for config with sha1: ' + configHash);
-          process(cachedResponseBody, callback);
+          processResponse(cachedResponseBody, callback);
         }
       });
     } else {


### PR DESCRIPTION
Hi,

I need to use gulp-fontello behind a corporate proxy, and it seems not tu use it. Please correct me if there is another workaround.

So here I added proxy to requests, based on the HTTP_PROXY environment variable.
I also needed to rename your "process" function, as process is a node global object needed to retrieve environment variables.

Thank you